### PR TITLE
Fixed app crash if any key has empty value

### DIFF
--- a/fig/src/main/kotlin/com/github/theapache64/fig/KeyValue.kt
+++ b/fig/src/main/kotlin/com/github/theapache64/fig/KeyValue.kt
@@ -8,5 +8,5 @@ data class KeyValue(
     @Json(name = "key")
     val key: String,
     @Json(name = "value")
-    val value: String
+    val value: String = ""
 )


### PR DESCRIPTION
Your project is great, but it has an issue, all credits goes to [Stevdza-San](https://www.youtube.com/watch?v=E8X94pCJ2zs&ab_channel=Stevdza-San) for finding the issue. 

If any key in your sheet has an empty value. Moshi isn't able to map it because it miss `value` field. Apparently, if you initialize `value` field in your mapper class, like with empty string that did in this PR, crash can be avoided.